### PR TITLE
Integration of ElnixNote into AlphaLLM App

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application
             android:allowBackup="true"
@@ -26,6 +27,14 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <!-- ContentProvider for sharing notes with AlphaLM app -->
+        <provider
+                android:name=".provider.NotesContentProvider"
+                android:authorities="org.elnix.notes.provider"
+                android:exported="true"
+                android:permission="android.permission.QUERY_ALL_PACKAGES">
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/elnix/notes/MainAppUi.kt
+++ b/app/src/main/java/org/elnix/notes/MainAppUi.kt
@@ -54,6 +54,7 @@ object Routes {
         const val BACKUP = "settings/backup"
         const val DEBUG = "settings/debug"
         const val LANGUAGE = "settings/language"
+        const val PLUGINS = "settings/plugins"
 
         object DebugSub {
             const val REMINDERS = "settings/debug/reminders"
@@ -168,6 +169,7 @@ fun NavGraphBuilder.settingsNavGraph(navController: NavHostController, vm: NoteV
         composable(Routes.Settings.SECURITY) { SecuritySettingsScreen(navController) }
         composable(Routes.Settings.BACKUP) { BackupSettingsScreen(navController) }
         composable(Routes.Settings.LANGUAGE) { LanguageSettingsScreen(navController) }
+        composable(Routes.Settings.PLUGINS) { PluginsSettingsScreen(navController) }
 
         composable(Routes.Settings.DEBUG) { DebugSettingsScreen(navController) }
         // Debug sub-settings

--- a/app/src/main/java/org/elnix/notes/SettingsScreen.kt
+++ b/app/src/main/java/org/elnix/notes/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DashboardCustomize
+import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.ReportProblem
 import androidx.compose.material.icons.filled.Shield
@@ -60,6 +61,7 @@ import org.elnix.notes.ui.helpers.TextDivider
 import org.elnix.notes.ui.helpers.UserValidation
 import org.elnix.notes.ui.settings.BackupTab
 import org.elnix.notes.ui.settings.CustomisationTab
+import org.elnix.notes.ui.settings.PluginsTab
 import org.elnix.notes.ui.settings.RemindersTab
 import org.elnix.notes.ui.settings.appearance.AppearanceTab
 import org.elnix.notes.ui.settings.appearance.ColorSelectorTab
@@ -144,6 +146,10 @@ fun SettingsListScreen(navController: NavController) {
                 }
             )
 
+            SettingsItem(
+                title = stringResource(R.string.plugins),
+                icon = Icons.Default.Extension
+            ) { navController.navigate(Routes.Settings.PLUGINS) }
 
             if (isDebugModeEnabled) {
                 SettingsItem(
@@ -332,6 +338,15 @@ fun BackupSettingsScreen(navController: NavController) {
 @Composable
 fun LanguageSettingsScreen(navController: NavController) {
     LanguageTab {
+        navController.popBackStack()
+    }
+}
+
+@Composable
+fun PluginsSettingsScreen(navController: NavController) {
+    val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
+    PluginsTab(ctx, scope) {
         navController.popBackStack()
     }
 }

--- a/app/src/main/java/org/elnix/notes/data/NoteRepository.kt
+++ b/app/src/main/java/org/elnix/notes/data/NoteRepository.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.Flow
 class NoteRepository(private val dao: NoteDao) {
     fun observeAll(): Flow<List<NoteEntity>> = dao.observeAll()
 
+    suspend fun getAllNotes(): List<NoteEntity> = dao.getAll()
+
     suspend fun getById(id: Long): NoteEntity? = dao.getById(id)
 
     suspend fun upsert(note: NoteEntity): Long {

--- a/app/src/main/java/org/elnix/notes/data/settings/stores/PluginsSettingsStore.kt
+++ b/app/src/main/java/org/elnix/notes/data/settings/stores/PluginsSettingsStore.kt
@@ -1,0 +1,26 @@
+package org.elnix.notes.data.settings.stores
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.elnix.notes.data.settings.dataStore
+
+object PluginsSettingsStore {
+
+    // AlphaLM app access permission
+    private val ALLOW_ALPHALLM_ACCESS = booleanPreferencesKey("allow_alphallm_access")
+    
+    fun getAllowAlphaLMAccess(ctx: Context): Flow<Boolean> =
+        ctx.dataStore.data.map { it[ALLOW_ALPHALLM_ACCESS] ?: false }
+
+    suspend fun setAllowAlphaLMAccess(ctx: Context, allowed: Boolean) {
+        ctx.dataStore.edit { it[ALLOW_ALPHALLM_ACCESS] = allowed }
+        // Also write to SharedPreferences for synchronous access in ContentProvider
+        ctx.getSharedPreferences("notes_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("allow_alphallm_access", allowed)
+            .apply()
+    }
+}

--- a/app/src/main/java/org/elnix/notes/provider/NotesContentProvider.kt
+++ b/app/src/main/java/org/elnix/notes/provider/NotesContentProvider.kt
@@ -1,0 +1,406 @@
+package org.elnix.notes.provider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import org.elnix.notes.data.NoteDao
+import org.elnix.notes.data.AppDatabase
+import org.elnix.notes.data.NoteRepository
+import kotlinx.coroutines.runBlocking
+
+/**
+ * ContentProvider for sharing notes with other apps (specifically AlphaLM)
+ * 
+ * Authority: org.elnix.notes.provider
+ * 
+ * Query Methods:
+ * - checkAppAvailable: Verify app is installed and available
+ * - searchNotes: Search notes by query
+ * - getNote: Get specific note by ID
+ * - getAllNotes: Get all notes without filtering
+ * - createNote: Create a new note
+ */
+class NotesContentProvider : ContentProvider() {
+
+    companion object {
+        const val AUTHORITY = "org.elnix.notes.provider"
+        const val TAG = "NotesContentProvider"
+        
+        // Allowed caller package
+        const val ALPHALLM_PACKAGE = "tech.alphallm.lucky"
+        
+        // Query methods
+        const val METHOD_CHECK_APP = "checkAppAvailable"
+        const val METHOD_SEARCH_NOTES = "searchNotes"
+        const val METHOD_GET_NOTE = "getNote"
+        const val METHOD_GET_ALL_NOTES = "getAllNotes"
+        const val METHOD_CREATE_NOTE = "createNote"
+        
+        // Cursor columns
+        private const val COLUMN_ID = "id"
+        private const val COLUMN_TITLE = "title"
+        private const val COLUMN_CONTENT = "content"
+        private const val COLUMN_CREATED_AT = "created_at"
+        private const val COLUMN_UPDATED_AT = "updated_at"
+        private const val COLUMN_TAGS = "tags"
+    }
+
+    private var noteRepository: NoteRepository? = null
+    private var prefs: SharedPreferences? = null
+
+    override fun onCreate(): Boolean {
+        return try {
+            val context = context ?: return false
+            // Initialize repository
+            noteRepository = NoteRepository(AppDatabase.get(context).noteDao())
+            // Initialize shared preferences for access control
+            prefs = context.getSharedPreferences("notes_prefs", Context.MODE_PRIVATE)
+            Log.d(TAG, "ContentProvider initialized successfully")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Error initializing ContentProvider", e)
+            false
+        }
+    }
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        Log.d(TAG, "=== CALL START ===")
+        Log.d(TAG, "call() invoked: method=$method, arg=$arg, extras=$extras")
+        return try {
+            // For checkAppAvailable, skip all verification as it's just checking availability
+            if (method != METHOD_CHECK_APP) {
+                // Verify caller
+                val callerPackage = getCallerPackage()
+                if (!isAllowedCaller(callerPackage)) {
+                    Log.w(TAG, "Unauthorized caller: $callerPackage")
+                    return Bundle().apply { putString("error", "Unauthorized caller" ) }
+                }
+
+                // Check if access is allowed in settings
+                if (!isAccessAllowed()) {
+                    Log.w(TAG, "AlphaLM access is disabled in settings")
+                    return Bundle().apply { putString("error", "Access denied by user") }
+                }
+            }
+
+            when (method) {
+                METHOD_CHECK_APP -> handleCheckApp()
+                METHOD_SEARCH_NOTES -> {
+                    Log.d(TAG, "Handling searchNotes with query from extras")
+                    handleSearchNotes(extras?.getString("query") ?: "")
+                }
+                METHOD_GET_NOTE -> {
+                    Log.d(TAG, "Handling getNote with noteId from extras")
+                    handleGetNote(extras?.getString("noteId") ?: "")
+                }
+                METHOD_GET_ALL_NOTES -> {
+                    Log.d(TAG, "Handling getAllNotes")
+                    handleGetAllNotes()
+                }
+                METHOD_CREATE_NOTE -> {
+                    Log.d(TAG, "Handling createNote with title from extras")
+                    handleCreateNote(extras?.getString("title") ?: "", extras?.getString("content") ?: "")
+                }
+                else -> {
+                    Log.w(TAG, "Unknown method: $method")
+                    Bundle().apply { putString("error", "Unknown method: $method") }
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error handling call", e)
+            Bundle().apply { putString("error", "Internal error: ${e.message}") }
+        }.also {
+            Log.d(TAG, "=== CALL END === Returning: $it")
+        }
+    }
+
+    /**
+     * Verify that the caller is an allowed package
+     */
+    private fun isAllowedCaller(callerPackage: String?): Boolean {
+        if (callerPackage == null) {
+            Log.w(TAG, "Caller package is null")
+            return false
+        }
+        val allowed = callerPackage == ALPHALLM_PACKAGE
+        if (!allowed) {
+            Log.w(TAG, "Caller package $callerPackage is not allowed (expecting $ALPHALLM_PACKAGE)")
+        }
+        return allowed
+    }
+
+    /**
+     * Check if user has allowed AlphaLM access
+     */
+    private fun isAccessAllowed(): Boolean {
+        return prefs?.getBoolean("allow_alphallm_access", true) ?: true
+    }
+
+    /**
+     * Handle checkAppAvailable method - verify app is running
+     */
+    private fun handleCheckApp(): Bundle {
+        Log.d(TAG, "handleCheckApp called")
+        return Bundle().apply {
+            putBoolean("available", true)
+            putString("version", "1.0.0")
+        }
+    }
+
+    /**
+     * Handle searchNotes method - search notes by query
+     */
+    private fun handleSearchNotes(query: String): Bundle {
+        Log.d(TAG, "[searchNotes] Starting search for query: '$query'")
+        return try {
+            if (query.isBlank()) {
+                Log.w(TAG, "[searchNotes] Empty search query")
+                return Bundle().apply { putString("error", "Empty search query") }
+            }
+
+            val repo = noteRepository ?: return Bundle().apply { 
+                Log.e(TAG, "[searchNotes] Repository not initialized")
+                putString("error", "Repository not initialized") 
+            }
+
+            Log.d(TAG, "[searchNotes] Starting database query...")
+            // Search notes (this is a simple substring search)
+            val notes = runBlocking {
+                Log.d(TAG, "[searchNotes] Inside runBlocking, calling getAllNotes()")
+                val allNotes = repo.getAllNotes()
+                Log.d(TAG, "[searchNotes] getAllNotes() returned ${allNotes.size} notes")
+                allNotes.filter { note ->
+                    note.title.contains(query, ignoreCase = true) ||
+                    note.desc.contains(query, ignoreCase = true)
+                }
+            }
+
+            Log.d(TAG, "[searchNotes] Found ${notes.size} notes matching query: $query")
+
+            val results = mutableListOf<Bundle>()
+            for (note in notes) {
+                val noteBundle = Bundle().apply {
+                    putLong("id", note.id)
+                    putString("title", note.title)
+                    putString("content", note.desc)
+                    putLong("created_at", note.createdAt.time)
+                    putLong("updated_at", note.lastEdit)
+                    putString("tags", note.tagIds.joinToString(","))
+                }
+                results.add(noteBundle)
+            }
+
+            Log.d(TAG, "[searchNotes] Returning ${results.size} result bundles")
+            Bundle().apply {
+                putParcelableArray("notes", results.toTypedArray())
+                putInt("count", results.size)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "[searchNotes] Error searching notes", e)
+            Bundle().apply { putString("error", "Search failed: ${e.message}") }
+        }.also {
+            Log.d(TAG, "[searchNotes] Returning bundle: $it")
+        }
+    }
+
+    /**
+     * Handle getAllNotes method - get all notes without filtering
+     */
+    private fun handleGetAllNotes(): Bundle {
+        Log.d(TAG, "[getAllNotes] Starting get all notes")
+        return try {
+            val repo = noteRepository ?: return Bundle().apply { 
+                Log.e(TAG, "[getAllNotes] Repository not initialized")
+                putString("error", "Repository not initialized") 
+            }
+
+            Log.d(TAG, "[getAllNotes] Starting database query...")
+            // Get all notes
+            val notes = runBlocking {
+                Log.d(TAG, "[getAllNotes] Inside runBlocking, calling getAllNotes()")
+                repo.getAllNotes()
+            }
+
+            Log.d(TAG, "[getAllNotes] Found ${notes.size} notes")
+
+            val results = mutableListOf<Bundle>()
+            for (note in notes) {
+                val noteBundle = Bundle().apply {
+                    putLong("id", note.id)
+                    putString("title", note.title)
+                    putString("content", note.desc)
+                    putLong("created_at", note.createdAt.time)
+                    putLong("updated_at", note.lastEdit)
+                    putString("tags", note.tagIds.joinToString(","))
+                }
+                results.add(noteBundle)
+            }
+
+            Log.d(TAG, "[getAllNotes] Returning ${results.size} result bundles")
+            Bundle().apply {
+                putParcelableArray("notes", results.toTypedArray())
+                putInt("count", results.size)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "[getAllNotes] Error getting all notes", e)
+            Bundle().apply { putString("error", "Get all notes failed: ${e.message}") }
+        }.also {
+            Log.d(TAG, "[getAllNotes] Returning bundle: $it")
+        }
+    }
+
+    /**
+     * Handle createNote method - create a new note
+     */
+    private fun handleCreateNote(title: String, content: String): Bundle {
+        Log.d(TAG, "[createNote] Starting create note with title: '$title'")
+        return try {
+            if (title.isBlank()) {
+                Log.w(TAG, "[createNote] Empty title")
+                return Bundle().apply { putString("error", "Empty title") }
+            }
+
+            val repo = noteRepository ?: return Bundle().apply { 
+                Log.e(TAG, "[createNote] Repository not initialized")
+                putString("error", "Repository not initialized") 
+            }
+
+            Log.d(TAG, "[createNote] Creating new note...")
+            // Create new note
+            val newNote = org.elnix.notes.data.NoteEntity(
+                title = title,
+                desc = content,
+                lastEdit = System.currentTimeMillis()
+            )
+
+            val noteId = runBlocking {
+                Log.d(TAG, "[createNote] Inside runBlocking, calling upsert")
+                repo.upsert(newNote)
+            }
+
+            Log.d(TAG, "[createNote] Note created with ID: $noteId")
+
+            Bundle().apply {
+                putLong("noteId", noteId)
+                putString("title", title)
+                putString("content", content)
+                putLong("createdAt", System.currentTimeMillis())
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "[createNote] Error creating note", e)
+            Bundle().apply { putString("error", "Create note failed: ${e.message}") }
+        }.also {
+            Log.d(TAG, "[createNote] Returning bundle: $it")
+        }
+    }
+
+    /**
+     * Handle getNote method - get specific note by ID
+     */
+    private fun handleGetNote(noteId: String): Bundle {
+        return try {
+            if (noteId.isBlank()) {
+                Log.w(TAG, "Empty note ID")
+                return Bundle().apply { putString("error", "Empty note ID") }
+            }
+
+            val id = noteId.toLongOrNull() ?: run {
+                Log.w(TAG, "Invalid note ID format: $noteId")
+                return Bundle().apply { putString("error", "Invalid note ID format") }
+            }
+
+            val repo = noteRepository ?: return Bundle().apply {
+                putString("error", "Repository not initialized")
+            }
+
+            val note = runBlocking { repo.getById(id) }
+
+            if (note == null) {
+                Log.w(TAG, "Note not found: $id")
+                return Bundle().apply { putString("error", "Note not found") }
+            }
+
+            Log.d(TAG, "Retrieved note: ${note.title}")
+
+            Bundle().apply {
+                putLong("id", note.id)
+                putString("title", note.title)
+                putString("content", note.desc)
+                putLong("created_at", note.createdAt.time)
+                putLong("updated_at", note.lastEdit)
+                putString("tags", note.tagIds.joinToString(","))
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error retrieving note", e)
+            Bundle().apply { putString("error", "Retrieval failed: ${e.message}") }
+        }
+    }
+
+    /**
+     * Get the package name of the caller
+     */
+    private fun getCallerPackage(): String? {
+        return try {
+            // Try the modern API first (API 29+)
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                val callingPackage = callingPackage
+                if (callingPackage != null) {
+                    Log.d(TAG, "Using modern API - calling package: $callingPackage")
+                    return callingPackage
+                }
+            }
+
+            // Fallback to Binder approach
+            val callingPid = android.os.Binder.getCallingPid()
+            val callingUid = android.os.Binder.getCallingUid()
+            Log.d(TAG, "Using Binder approach - PID: $callingPid, UID: $callingUid")
+
+            val context = context ?: return null
+            val pm = context.packageManager
+            val packages = pm.getPackagesForUid(callingUid)
+            val callerPackage = packages?.firstOrNull()
+            Log.d(TAG, "Detected caller package: $callerPackage")
+            callerPackage
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting caller package", e)
+            null
+        }
+    }
+
+    // Not implemented - not needed for query operations
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    // Not implemented - not needed for this use case
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    // Not implemented - not needed for this use case
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+
+    // Not implemented - not needed for this use case
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+
+    // Not implemented - not needed for this use case
+    override fun getType(uri: Uri): String? = null
+}

--- a/app/src/main/java/org/elnix/notes/ui/settings/PluginsTab.kt
+++ b/app/src/main/java/org/elnix/notes/ui/settings/PluginsTab.kt
@@ -1,0 +1,60 @@
+package org.elnix.notes.ui.settings
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.elnix.notes.R
+import org.elnix.notes.data.settings.stores.PluginsSettingsStore
+import org.elnix.notes.ui.helpers.SettingsTitle
+import org.elnix.notes.ui.helpers.SwitchRow
+import org.elnix.notes.ui.helpers.TextDivider
+
+@Composable
+fun PluginsTab(ctx: Context, scope: CoroutineScope, onBack: (() -> Unit)) {
+    val allowAlphaLMAccess by PluginsSettingsStore.getAllowAlphaLMAccess(ctx).collectAsState(initial = false)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState())
+            .padding(
+                WindowInsets.systemBars
+                    .asPaddingValues()
+            )
+            .padding(horizontal = 16.dp, vertical = 5.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        SettingsTitle(title = stringResource(R.string.plugins), onBack = onBack)
+
+        TextDivider(stringResource(R.string.connected_apps))
+
+        // AlphaLM App Access Toggle
+        SwitchRow(
+            state = allowAlphaLMAccess,
+            text = stringResource(R.string.alphallm_app),
+            onCheck = { newState ->
+                scope.launch {
+                    PluginsSettingsStore.setAllowAlphaLMAccess(ctx, newState)
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -146,4 +146,8 @@
     <string name="edit">Editer</string>
     <string name="complete">Compléter</string>
     <string name="select">Select</string>
+    <string name="plugins">Plugins</string>
+    <string name="connected_apps">Applications Connectées</string>
+    <string name="alphallm_app">Autoriser l\'accès à AlphaLM</string>
+    <string name="alphallm_access_description">Permettre à l\'application AlphaLM de rechercher et accéder à vos notes</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,4 +157,8 @@
     <string name="back">Back</string>
     <string name="no_notes_show_due_to_filters">No notes shown due to filters rules</string>
     <string name="reorder_function_doesnt_work_yet">Reorder function doesn\'t work yet</string>
+    <string name="plugins">Plugins</string>
+    <string name="connected_apps">Connected Apps</string>
+    <string name="alphallm_app">Allow AlphaLM App Access</string>
+    <string name="alphallm_access_description">Allow the AlphaLM app to search and access your notes</string>
 </resources>


### PR DESCRIPTION
**Add comprehensive ElnixNotes integration to AlphaLLM chat app
- Add getAllNotes() method to ContentProvider for retrieving all notes without query filtering
- Add createNote() method to ContentProvider for creating new notes from AI responses
- Update ContentProvider documentation with new methods
- Improve error handling and logging for note operations**

@LuckyTheCookie


Summary By Copilot AI :
This pull request introduces a new Plugins settings section to the app, allowing users to manage integrations with external apps, specifically enabling or disabling access for the AlphaLM app. It adds the necessary UI, settings storage, and permissions to support this feature, and updates the manifest and resources accordingly.

**Plugins settings and AlphaLM app integration:**

* Added a new `PluginsSettingsScreen` and corresponding navigation route, along with a `PluginsTab` UI component for managing plugin-related settings, including a toggle for AlphaLM app access (`MainAppUi.kt`, `SettingsScreen.kt`, `PluginsTab.kt`).
* Implemented `PluginsSettingsStore` for persisting the AlphaLM app access permission, storing it in both DataStore and SharedPreferences for synchronous access by the content provider (`PluginsSettingsStore.kt`).

**Android manifest and permissions:**

* Added the `QUERY_ALL_PACKAGES` permission to the manifest to support external app queries, and registered a new `NotesContentProvider` for sharing notes with the AlphaLM app (`AndroidManifest.xml`).

**Localization and resources:**

* Updated English and French string resources to include new labels and descriptions for the Plugins section and AlphaLM app access (`strings.xml`, `values-fr/strings.xml`).
**Repository support for content provider:**

* Added a new method `getAllNotes()` to `NoteRepository` for retrieving all notes, supporting external access via the content provider (`NoteRepository.kt`).